### PR TITLE
Use arq-liberty-managed/test-persistence.xml for test JPA; use jpa2.2

### DIFF
--- a/src/test/arq-liberty-managed/test-persistence.xml
+++ b/src/test/arq-liberty-managed/test-persistence.xml
@@ -3,8 +3,9 @@
 	xmlns="http://xmlns.jcp.org/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
-	<persistence-unit name="coffees">
-		<jta-data-source>java:app/jdbc/JakartaEECafeDB</jta-data-source>
+	<persistence-unit name="coffees" transaction-type="JTA">
+	<jta-data-source>jdbc/JakartaEECafeDB</jta-data-source>
+	<exclude-unlisted-classes>false</exclude-unlisted-classes>
 		<properties>
 			<property
 				name="javax.persistence.schema-generation.database.action"

--- a/src/test/java/org/eclipse/jakarta/cafe/rest/it/CafeResourceTest.java
+++ b/src/test/java/org/eclipse/jakarta/cafe/rest/it/CafeResourceTest.java
@@ -56,7 +56,7 @@ public class CafeResourceTest {
 				.addClass(CafeRepository.class)
 				.addClass(Coffee.class)
 				.addClasses(CafeResource.class, JaxrsActivator.class)
-				.addAsResource("META-INF/persistence.xml", "META-INF/persistence.xml")
+				.addAsResource("test-persistence.xml", "META-INF/persistence.xml")
 				// Enable CDI
 				.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 	}


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

# FIXED TEST

OK, I got it to work so the tests pass.    I added the ShrinkWrap call to replace the src/main... persistence.xml with a test one (which I added to `src/test/arq-liberty-managed`...see question below).

This test one does NOT include the "load" script, so as to match the expectation in the **testGetAllCoffees()** assertion:

> 		assertEquals(coffees.size(), 3);

(I assumed you wanted to change the load behavior and keep that logic).    Also thought I might as well bump the jpa version in persistence.xml up to 2.2

# OTHER COMMENTS/ QUESTIONS 

I did review a bit more and have a couple more questions:

## common or separate test resources?

I see instead of simply using the typical `src/test/resources` you have an extra `src/test/arq-liberty-managed`, and the latter is where I added the test persistence.xml.

Is the src/test/resources supposed to be just for Glassfish?  Or are you trying to "merge" Liberty-specific stuff from the liberty dir into a more general, common src/test/resources?     (The merge would seem complicated IMHO).

## Liberty install technique 

I think you'll have an easier time generally using the liberty goals: `liberty:create liberty:install-feature` to install Liberty into **target** rather than `dependency:unpack`, e.g. as in our Open Liberty Arquillian [guide sample](https://openliberty.io/guides/arquillian-managed.html). 

However, personally I'm not too familiar with **arquillian-liberty-support**, so I left that alone for now.  Will try to take a further look or ask someone to. 

## assert method parms

It looks like the assertEquals have the expected, actual reversed.  
(see https://junit.org/junit4/javadoc/latest/org/junit/Assert.html)

Obviously it still validates correctly, but you get a more confusing error message.

E.g. should be:
> assertEquals(3, coffees.size());

instead of:
> assertEquals(coffees.size(), 3);

Might be a change worth making.




